### PR TITLE
Move user-based path setting out of Config object

### DIFF
--- a/message_ix_buildings/chilled/core/climate.py
+++ b/message_ix_buildings/chilled/core/climate.py
@@ -60,6 +60,7 @@ def create_climate_variables_maps(config: "Config", start_time: datetime.datetim
     project_path = get_paths(config, "project_path")
     dle_path = get_paths(config, "dle_path")
     isimip_bias_adj_path = get_paths(config, "isimip_bias_adj_path")
+    isimip_ewembi_path = get_paths(config, "isimip_ewembi_path")
 
     out_path = os.path.join(project_path, "out", "version", config.vstr)
     archetype_path = os.path.join(out_path, "rasters")
@@ -110,7 +111,7 @@ def create_climate_variables_maps(config: "Config", start_time: datetime.datetim
         endstr = ".nc"
 
         if str(clim) == "hist":
-            isi_folder = isimip_ewemib_path
+            isi_folder = isimip_ewembi_path
             filestr = climate_filestr_hist
         else:
             isi_folder = isimip_bias_adj_path

--- a/message_ix_buildings/chilled/core/climate.py
+++ b/message_ix_buildings/chilled/core/climate.py
@@ -48,6 +48,7 @@ from message_ix_buildings.chilled.util.config import Config  # type: ignore
 from message_ix_buildings.chilled.util.util import (
     get_archs,
     get_logger,
+    get_paths,
     load_all_scenarios_data,
     load_parametric_analysis_data,
 )
@@ -56,7 +57,11 @@ log = get_logger(__name__)
 
 
 def create_climate_variables_maps(config: "Config", start_time: datetime.datetime):
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    dle_path = get_paths(config, "dle_path")
+    isimip_bias_adj_path = get_paths(config, "isimip_bias_adj_path")
+
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     archetype_path = os.path.join(out_path, "rasters")
     save_path = os.path.join(out_path, "VDD_ene_calcs")
 
@@ -105,10 +110,10 @@ def create_climate_variables_maps(config: "Config", start_time: datetime.datetim
         endstr = ".nc"
 
         if str(clim) == "hist":
-            isi_folder = config.isimip_ewemib_path
+            isi_folder = isimip_ewemib_path
             filestr = climate_filestr_hist
         else:
-            isi_folder = config.isimip_bias_adj_path
+            isi_folder = isimip_bias_adj_path
             filestr = climate_filestr_future
 
         filepath = os.path.join(
@@ -135,12 +140,12 @@ def create_climate_variables_maps(config: "Config", start_time: datetime.datetim
         t_oa_gbm = t_out_ave.groupby("time.month")
 
         i_sol_v = xr.open_dataarray(
-            os.path.join(config.dle_path, "EWEMBI_vert_irrad_1980-2009_avg.nc")
+            os.path.join(dle_path, "EWEMBI_vert_irrad_1980-2009_avg.nc")
         )  # Values  in daily Wh/m2
 
         # Horizontal irradiation
         i_sol_h = xr.open_dataarray(
-            os.path.join(config.dle_path, "EWEMBI_horiz_irrad_1980-2009_avg.nc")
+            os.path.join(dle_path, "EWEMBI_horiz_irrad_1980-2009_avg.nc")
         )  # Values in daily Wh/m2
 
         if config.arch_setting == "regional":
@@ -756,7 +761,8 @@ def create_climate_variables_maps(config: "Config", start_time: datetime.datetim
 
 
 def aggregate_urban_rural_files(config: "Config"):
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     save_path = os.path.join(out_path, "VDD_ene_calcs")
 
     output_path_vdd = os.path.join(
@@ -834,7 +840,8 @@ def aggregate_urban_rural_files(config: "Config"):
 
 
 def make_vdd_total_maps(config: "Config"):
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     save_path = os.path.join(out_path, "VDD_ene_calcs")
 
     output_path_vdd = os.path.join(
@@ -1133,7 +1140,9 @@ def make_vdd_total_maps(config: "Config"):
 
 
 def process_construction_shares(config: "Config"):
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    dle_path = get_paths(config, "dle_path")
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     floorarea_path = os.path.join(out_path, "floorarea_country")
 
     output_path = os.path.join(
@@ -1153,7 +1162,7 @@ def process_construction_shares(config: "Config"):
 
     # If constr_setting == 1, then process construction shares. Otherwise, skip
     if config.constr_setting == 1:
-        input_path = config.dle_path
+        input_path = dle_path
 
         dsc = xr.Dataset()
         for urt in config.urts:
@@ -1226,8 +1235,10 @@ def process_construction_shares(config: "Config"):
 
 
 def process_floor_area_maps(config: "Config"):
-    input_path = config.dle_path
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    dle_path = get_paths(config, "dle_path")
+    input_path = dle_path
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     save_path = os.path.join(out_path, "floorarea_country")
 
     output_path = os.path.join(
@@ -1354,8 +1365,11 @@ def process_floor_area_maps(config: "Config"):
 
 
 def process_country_maps(config: "Config"):
-    input_path = config.dle_path
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    dle_path = get_paths(config, "dle_path")
+
+    input_path = dle_path
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     save_path = os.path.join(out_path, "floorarea_country")
 
     output_path = os.path.join(
@@ -1436,8 +1450,11 @@ def process_country_maps(config: "Config"):
 
 
 def process_final_maps(config: "Config"):
-    input_path = config.dle_path
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    dle_path = get_paths(config, "dle_path")
+
+    input_path = dle_path
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     vdd_path = os.path.join(
         out_path,
         "VDD_ene_calcs",
@@ -1835,8 +1852,11 @@ def process_final_maps(config: "Config"):
 def process_iso_tables(config: "Config"):
     start = datetime.datetime.now()
 
-    input_path = config.dle_path
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    dle_path = get_paths(config, "dle_path")
+
+    input_path = dle_path
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     vdd_path = os.path.join(out_path, "VDD_ene_calcs", config.gcm, config.rcp)
     floorarea_path = os.path.join(out_path, "floorarea_country", config.gcm, config.rcp)
     finalmaps_path = os.path.join(out_path, "final_maps", config.gcm, config.rcp)
@@ -2140,7 +2160,11 @@ def process_iso_tables(config: "Config"):
 
 
 def create_climate_outputs(config: "Config", start_time: datetime.datetime):
-    out_path = os.path.join(config.project_path, "out", "version", config.vstr)
+    project_path = get_paths(config, "project_path")
+    dle_path = get_paths(config, "dle_path")
+    isimip_bias_adj_path = get_paths(config, "isimip_bias_adj_path")
+    isimip_ewemib_path = get_paths(config, "isimip_ewemib_path")
+    out_path = os.path.join(project_path, "out", "version", config.vstr)
     archetype_path = os.path.join(out_path, "rasters")
     save_path = os.path.join(out_path, "VDD_ene_calcs")
 
@@ -2180,10 +2204,10 @@ def create_climate_outputs(config: "Config", start_time: datetime.datetime):
         nyrs_clim = int(years_clim[1]) - int(years_clim[0]) + 1
 
         if str(clim) == "hist":
-            isi_folder = config.isimip_ewemib_path
+            isi_folder = isimip_ewemib_path
             filestr = config.climate_filestr_hist
         else:
-            isi_folder = config.isimip_bias_adj_path
+            isi_folder = isimip_bias_adj_path
             filestr = config.climate_filestr_future
 
         filepath = os.path.join(
@@ -2226,12 +2250,12 @@ def create_climate_outputs(config: "Config", start_time: datetime.datetime):
         # Vertical irradiation
         # i_sol_v = xr.open_dataarray(input_folder+'CERES_vert_irrad_2001-13_avg.nc') #Values  in daily Wh/m2
         i_sol_v = xr.open_dataarray(
-            os.path.join(config.dle_path, "EWEMBI_vert_irrad_1980-2009_avg.nc")
+            os.path.join(dle_path, "EWEMBI_vert_irrad_1980-2009_avg.nc")
         )  # Values  in daily Wh/m2
 
         # Horizontal irradiation
         i_sol_h = xr.open_dataarray(
-            os.path.join(config.dle_path, "EWEMBI_horiz_irrad_1980-2009_avg.nc")
+            os.path.join(dle_path, "EWEMBI_horiz_irrad_1980-2009_avg.nc")
         )  # Values in daily Wh/m2
 
         # i_sol = i_sol.sel(time=slice(years_clim[0],years_clim[1]))

--- a/message_ix_buildings/chilled/postprocess/postprocess.py
+++ b/message_ix_buildings/chilled/postprocess/postprocess.py
@@ -3,10 +3,11 @@ import os
 import pandas as pd
 
 from message_ix_buildings.chilled.util.config import Config
-from message_ix_buildings.chilled.util.util import get_logger
+from message_ix_buildings.chilled.util.util import get_logger, get_paths
 
 log = get_logger(__name__)
-cfg = Config()
+cfg = Config(user="MEAS")
+dle_path = get_paths(cfg, "dle_path")
 
 
 def get_sturm_data(input_path, input_version_name):
@@ -254,4 +255,4 @@ def postprocess_electricity_demand(input_path, input_version_name):
     )
 
 
-postprocess_electricity_demand(cfg.dle_path, cfg.vstr)
+postprocess_electricity_demand(dle_path, cfg.vstr)

--- a/message_ix_buildings/chilled/postprocess/postprocess.py
+++ b/message_ix_buildings/chilled/postprocess/postprocess.py
@@ -255,4 +255,4 @@ def postprocess_electricity_demand(input_path, input_version_name):
     )
 
 
-postprocess_electricity_demand(dle_path, cfg.vstr)
+postprocess_electricity_demand(dle_path, cfg.vstr2 + "_" + cfg.vstr)

--- a/message_ix_buildings/chilled/preprocess/archetypes.py
+++ b/message_ix_buildings/chilled/preprocess/archetypes.py
@@ -15,6 +15,7 @@ from message_ix_buildings.chilled.util.config import Config  # type: ignore
 from message_ix_buildings.chilled.util.util import (
     get_archs,
     get_logger,
+    get_paths,
     read_arch_inputs_df,
     read_arch_reg_df,
 )
@@ -23,7 +24,9 @@ log = get_logger(__name__)
 
 
 def create_archetypes(config: "Config"):
-    out_path = os.path.join(config.project_path, "out", "version")
+    project_path = get_paths(config, "dle_path")
+
+    out_path = os.path.join(project_path, "out", "version")
     archetype_path = os.path.join(out_path, config.vstr, "rasters")
 
     # if archetypes folder does not exist, create it
@@ -101,7 +104,9 @@ def create_archetypes(config: "Config"):
 
 
 def create_archetype_variables(config: "Config"):
-    out_path = os.path.join(config.project_path, "out", "version")
+    project_path = get_paths(config, "dle_path")
+
+    out_path = os.path.join(project_path, "out", "version")
     archetype_path = os.path.join(out_path, config.vstr, "rasters")
 
     # get archs

--- a/message_ix_buildings/chilled/preprocess/message_raster.py
+++ b/message_ix_buildings/chilled/preprocess/message_raster.py
@@ -10,6 +10,7 @@ import pandas as pd
 import xarray as xr
 
 from message_ix_buildings.chilled.util.config import Config
+from message_ix_buildings.chilled.util.util import get_paths
 
 
 def create_message_raster(config: "Config"):
@@ -35,11 +36,12 @@ def create_message_raster(config: "Config"):
         ISO attributes in a dataframe
 
     """
-    input_path = os.path.join(config.dle_path)
+    input_path = get_paths(config, "dle_path")
+    message_region_file = get_paths(config, "message_region_map_file")
 
     if config.node == "R11":
         msgregions = pd.read_excel(
-            config.message_region_file,
+            message_region_file,
             sheet_name="regional definition",
         )
 

--- a/message_ix_buildings/chilled/util/config.py
+++ b/message_ix_buildings/chilled/util/config.py
@@ -18,6 +18,7 @@ class Config:
     #:
     #: This is used to name the output files and directories.
     vstr: str = "ALPS2023"
+    vstr2 = "v19"
 
     #: Select the climate model.
     #:

--- a/message_ix_buildings/chilled/util/config.py
+++ b/message_ix_buildings/chilled/util/config.py
@@ -4,8 +4,6 @@ from typing import Literal
 
 import numpy as np
 
-from message_ix_buildings.chilled.functions.user_settings import DICT_USER_SETTINGS
-
 
 @dataclass
 class Config:
@@ -127,14 +125,6 @@ class Config:
     #: Currently only "R11" is supported.
     #: TODO: In the future, support "R12".
     node: Literal["R11"] = "R11"
-
-    #: Paths settings by user
-    project_path: str = str(DICT_USER_SETTINGS[user]["project_path"])
-    dle_path: str = str(DICT_USER_SETTINGS[user]["dle_path"])
-    message_region_file: str = str(DICT_USER_SETTINGS[user]["message_region_map_file"])
-    isimip_bias_adj_path: str = str(DICT_USER_SETTINGS[user]["isimip_bias_adj_path"])
-    isimip_ewemib_path: str = str(DICT_USER_SETTINGS[user]["isimip_ewembi_path"])
-    chunk_size = DICT_USER_SETTINGS[user]["chunk_size"]
 
     #: NetCDF settings
     netcdf4_format = "NETCDF4_CLASSIC"

--- a/message_ix_buildings/chilled/util/util.py
+++ b/message_ix_buildings/chilled/util/util.py
@@ -3,11 +3,22 @@ import os
 from pathlib import Path
 
 import pandas as pd
-from util.config import Config  # type: ignore
+
+from message_ix_buildings.chilled.functions.user_settings import DICT_USER_SETTINGS
+from message_ix_buildings.chilled.util.config import Config  # type: ignore
 
 
 def get_project_root() -> Path:
     return Path(__file__).parent.parent.parent
+
+
+def get_paths(config: "Config", selection):
+    # if selection is chunk_size, then return chunk_size as is
+    # else, return string version of the path
+    if selection == "chunk_size":
+        return DICT_USER_SETTINGS[config.user][selection]
+    else:
+        return str(DICT_USER_SETTINGS[config.user][selection])
 
 
 def get_logger(name: str):


### PR DESCRIPTION
This PR changes where and how the user-based paths for data is set.

Previously, this was done within the Config object, but with this PR it will be done in a function outside of the Config object. This PR should address #31 

There is also a small change to save a file in postprocessing, which was done as part of #34, then merged into this branch

This branch is based off of `chilled/input-files`, which is associated with the PR #29 